### PR TITLE
Move the `editor` into the function

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,7 @@
 const vscode = require('vscode');
-const editor = vscode.window.activeTextEditor;
 
 function duplicateText() {
+  const editor = vscode.window.activeTextEditor;
 
   if (!editor) {
     return;


### PR DESCRIPTION
so that it gets set on every function call, thus eliminating the `TextEditor#edit not possible on closed editors` error.

Fix #2